### PR TITLE
fix: add setuptools for Python 3.12 compatibility

### DIFF
--- a/requirement.txt
+++ b/requirement.txt
@@ -14,6 +14,7 @@ selenium
 tornado
 undetected-chromedriver
 urllib3
+setuptools; python_version >= '3.12'
 #PS: nodriver need python 3.9+
 # nodriver max modified version:
 # python -m pip install git+https://github.com/max32002/nodriver


### PR DESCRIPTION
Python 3.12 刪除了某些軟體包所需的 distutils 模組。
distutils 的功能已經被合併進 setuptools
此提交將 setuptools 新增為 Python 版本 >= 3.12 的依賴項
確保相容性。